### PR TITLE
Prevent hiding content with height-limit

### DIFF
--- a/src/Whoops/Resources/css/whoops.base.css
+++ b/src/Whoops/Resources/css/whoops.base.css
@@ -228,7 +228,6 @@ header {
     }
 
     .code-block {
-      max-height: 345px;
       overflow: hidden;
       padding: 10px;
       margin: 0;


### PR DESCRIPTION
Removing height-limit attribute from .code-block to prevent hiding content/arguments/comments
NB: we don't risk to have big huge page cause by default
- code view limite the number of line to 40 $range = $frame->getFileLines($line - 20, 40);
- arguments view collapse array content